### PR TITLE
Added messageque stability

### DIFF
--- a/src/messageq.py
+++ b/src/messageq.py
@@ -7,8 +7,9 @@ import json
 class MessageQueue():
     def __init__(self, queue_name):
         self.queue = queue_name
-        self.connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+        self.connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost', heartbeat=6000))
         self.channel = self.connection.channel()
+        self.channel.queue_purge(queue=queue_name)
         self.channel.queue_declare(queue=queue_name)
         print(f"{queue_name} declared")
     


### PR DESCRIPTION
Sometimes old Messages stay lingering in the MessageQueue structure. `channel.purge_queue` should get rid of the old messages.

Also sometimes the Classification or the Validation take so long that the MessageQue closes. By increasing heartbeat this should no longer happen. 